### PR TITLE
docs: Correct examples and import of sonarr_naming resource

### DIFF
--- a/docs/resources/naming.md
+++ b/docs/resources/naming.md
@@ -16,7 +16,7 @@ For more information refer to [Naming](https://wiki.servarr.com/sonarr/settings#
 ## Example Usage
 
 ```terraform
-resource "sonarr_media_management" "example" {
+resource "sonarr_naming" "example" {
   rename_episodes            = true
   replace_illegal_characters = true
   multi_episode_style        = 0
@@ -56,5 +56,5 @@ Import is supported using the following syntax:
 
 ```shell
 # import does not need parameters
-terraform import sonarr_indexer_config.example ""
+terraform import sonarr_naming.example ""
 ```

--- a/examples/resources/sonarr_naming/import.sh
+++ b/examples/resources/sonarr_naming/import.sh
@@ -1,2 +1,2 @@
 # import does not need parameters
-terraform import sonarr_indexer_config.example ""
+terraform import sonarr_naming.example ""

--- a/examples/resources/sonarr_naming/resource.tf
+++ b/examples/resources/sonarr_naming/resource.tf
@@ -1,4 +1,4 @@
-resource "sonarr_media_management" "example" {
+resource "sonarr_naming" "example" {
   rename_episodes            = true
   replace_illegal_characters = true
   multi_episode_style        = 0


### PR DESCRIPTION
This PR just fixes some references in documentation of `sonarr_naming` resource.

No code is modified, only docs.

Thanks for this project!