### PR TITLE
feat: add map_from and map_to to emby and plex notifications

### DIFF
--- a/docs/data-sources/notification.md
+++ b/docs/data-sources/notification.md
@@ -70,6 +70,8 @@ data "sonarr_notification" "example" {
 - `import_fields` (Set of Number) Import fields. `0` Overview, `1` Rating, `2` Genres, `3` Quality, `4` Codecs, `5` Group, `6` Size, `7` Languages, `8` Subtitles, `9` Links, `10` Release, `11` Poster, `12` Fanart.
 - `include_health_warnings` (Boolean) Include health warnings.
 - `key` (String, Sensitive) Key.
+- `map_from` (String) Map from. Sonarr path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')
+- `map_to` (String) Map to. Media server path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')
 - `mention` (String) Mention.
 - `method` (Number) Method. `1` POST, `2` PUT.
 - `notification_type` (Number) Notification type. `0` Info, `1` Success, `2` Warning, `3` Failure.

--- a/docs/data-sources/notifications.md
+++ b/docs/data-sources/notifications.md
@@ -77,6 +77,8 @@ Read-Only:
 - `import_fields` (Set of Number) Import fields. `0` Overview, `1` Rating, `2` Genres, `3` Quality, `4` Codecs, `5` Group, `6` Size, `7` Languages, `8` Subtitles, `9` Links, `10` Release, `11` Poster, `12` Fanart.
 - `include_health_warnings` (Boolean) Include health warnings.
 - `key` (String, Sensitive) Key.
+- `map_from` (String) Map from. Sonarr path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')
+- `map_to` (String) Map to. Media server path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')
 - `mention` (String) Mention.
 - `method` (Number) Method. `1` POST, `2` PUT.
 - `notification_type` (Number) Notification type. `0` Info, `1` Success, `2` Warning, `3` Failure.

--- a/docs/resources/notification.md
+++ b/docs/resources/notification.md
@@ -87,6 +87,8 @@ resource "sonarr_notification" "example" {
 - `import_fields` (Set of Number) Import fields. `0` Overview, `1` Rating, `2` Genres, `3` Quality, `4` Codecs, `5` Group, `6` Size, `7` Languages, `8` Subtitles, `9` Links, `10` Release, `11` Poster, `12` Fanart.
 - `include_health_warnings` (Boolean) Include health warnings.
 - `key` (String, Sensitive) Key.
+- `map_from` (String) Map from. Sonarr path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')
+- `map_to` (String) Map to. Media server path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')
 - `mention` (String) Mention.
 - `method` (Number) Method. `1` POST, `2` PUT.
 - `notification_type` (Number) Notification type. `0` Info, `1` Success, `2` Warning, `3` Failure.

--- a/docs/resources/notification_emby.md
+++ b/docs/resources/notification_emby.md
@@ -33,6 +33,12 @@ resource "sonarr_notification_emby" "example" {
   host    = "emby.lcl"
   port    = 8096
   api_key = "API_Key"
+
+  # optional path mapping, for when Sonarr and Emby/Jellyfin see the library at
+  # different paths. only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/tv"
+  map_to         = "/media/tv"
 }
 ```
 
@@ -48,6 +54,8 @@ resource "sonarr_notification_emby" "example" {
 ### Optional
 
 - `include_health_warnings` (Boolean) Include health warnings.
+- `map_from` (String) Map from. Sonarr path, used to modify series paths when Jellyfin sees library path location differently from Sonarr (Requires 'Update Library')
+- `map_to` (String) Map to. Jellyfin path, used to modify series paths when Jellyfin sees library path location differently from Sonarr (Requires 'Update Library')
 - `notify` (Boolean) Notify flag.
 - `on_application_update` (Boolean) On application update flag.
 - `on_download` (Boolean) On download flag.

--- a/docs/resources/notification_plex.md
+++ b/docs/resources/notification_plex.md
@@ -30,6 +30,12 @@ resource "sonarr_notification_plex" "example" {
   host       = "plex.lcl"
   port       = 32400
   auth_token = "AuthTOKEN"
+
+  # optional path mapping, for when Sonarr and Plex see the library at different
+  # paths. only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/tv"
+  map_to         = "/media/tv"
 }
 ```
 
@@ -45,6 +51,8 @@ resource "sonarr_notification_plex" "example" {
 ### Optional
 
 - `include_health_warnings` (Boolean) Include health warnings.
+- `map_from` (String) Map from. Sonarr path, used to modify series paths when Plex sees library path location differently from Sonarr (Requires 'Update Library')
+- `map_to` (String) Map to. Plex path, used to modify series paths when Plex sees library path location differently from Sonarr (Requires 'Update Library')
 - `on_download` (Boolean) On download flag.
 - `on_episode_file_delete` (Boolean) On episode file delete flag.
 - `on_episode_file_delete_for_upgrade` (Boolean) On episode file delete for upgrade flag.

--- a/examples/resources/sonarr_notification_emby/resource.tf
+++ b/examples/resources/sonarr_notification_emby/resource.tf
@@ -15,4 +15,10 @@ resource "sonarr_notification_emby" "example" {
   host    = "emby.lcl"
   port    = 8096
   api_key = "API_Key"
+
+  # optional path mapping, for when Sonarr and Emby/Jellyfin see the library at
+  # different paths. only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/tv"
+  map_to         = "/media/tv"
 }

--- a/examples/resources/sonarr_notification_plex/resource.tf
+++ b/examples/resources/sonarr_notification_plex/resource.tf
@@ -12,4 +12,10 @@ resource "sonarr_notification_plex" "example" {
   host       = "plex.lcl"
   port       = 32400
   auth_token = "AuthTOKEN"
+
+  # optional path mapping, for when Sonarr and Plex see the library at different
+  # paths. only applied when update_library is enabled.
+  update_library = true
+  map_from       = "/tv"
+  map_to         = "/media/tv"
 }

--- a/internal/provider/notification_data_source.go
+++ b/internal/provider/notification_data_source.go
@@ -178,6 +178,14 @@ func (d *NotificationDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 				MarkdownDescription: "Stateless URLs.",
 				Computed:            true,
 			},
+			"map_from": schema.StringAttribute{
+				MarkdownDescription: "Map from. Sonarr path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')",
+				Computed:            true,
+			},
+			"map_to": schema.StringAttribute{
+				MarkdownDescription: "Map to. Media server path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')",
+				Computed:            true,
+			},
 			"configuration_key": schema.StringAttribute{
 				MarkdownDescription: "Configuration key.",
 				Computed:            true,

--- a/internal/provider/notification_emby_resource.go
+++ b/internal/provider/notification_emby_resource.go
@@ -44,6 +44,8 @@ type NotificationEmby struct {
 	Host                          types.String `tfsdk:"host"`
 	APIKey                        types.String `tfsdk:"api_key"`
 	Name                          types.String `tfsdk:"name"`
+	MapFrom                       types.String `tfsdk:"map_from"`
+	MapTo                         types.String `tfsdk:"map_to"`
 	ID                            types.Int64  `tfsdk:"id"`
 	Port                          types.Int64  `tfsdk:"port"`
 	UpdateLibrary                 types.Bool   `tfsdk:"update_library"`
@@ -70,6 +72,8 @@ func (n NotificationEmby) toNotification() *Notification {
 		Host:                          n.Host,
 		Name:                          n.Name,
 		APIKey:                        n.APIKey,
+		MapFrom:                       n.MapFrom,
+		MapTo:                         n.MapTo,
 		ID:                            n.ID,
 		Port:                          n.Port,
 		UpdateLibrary:                 n.UpdateLibrary,
@@ -98,6 +102,8 @@ func (n *NotificationEmby) fromNotification(notification *Notification) {
 	n.Host = notification.Host
 	n.Name = notification.Name
 	n.APIKey = notification.APIKey
+	n.MapFrom = notification.MapFrom
+	n.MapTo = notification.MapTo
 	n.ID = notification.ID
 	n.UpdateLibrary = notification.UpdateLibrary
 	n.Port = notification.Port
@@ -237,6 +243,16 @@ func (r *NotificationEmbyResource) Schema(_ context.Context, _ resource.SchemaRe
 			"host": schema.StringAttribute{
 				MarkdownDescription: "Host.",
 				Required:            true,
+			},
+			"map_from": schema.StringAttribute{
+				MarkdownDescription: "Map from. Sonarr path, used to modify series paths when Jellyfin sees library path location differently from Sonarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
+			},
+			"map_to": schema.StringAttribute{
+				MarkdownDescription: "Map to. Jellyfin path, used to modify series paths when Jellyfin sees library path location differently from Sonarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
 			},
 		},
 	}

--- a/internal/provider/notification_emby_resource_test.go
+++ b/internal/provider/notification_emby_resource_test.go
@@ -25,6 +25,8 @@ func TestAccNotificationEmbyResource(t *testing.T) {
 				Config: testAccNotificationEmbyResourceConfig("resourceEmbyTest", "token123"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("sonarr_notification_emby.test", "api_key", "token123"),
+					resource.TestCheckResourceAttr("sonarr_notification_emby.test", "map_from", "/tv"),
+					resource.TestCheckResourceAttr("sonarr_notification_emby.test", "map_to", "/media/tv"),
 					resource.TestCheckResourceAttrSet("sonarr_notification_emby.test", "id"),
 				),
 			},
@@ -71,5 +73,8 @@ func testAccNotificationEmbyResourceConfig(name, token string) string {
 		host = "emby.lcl"
 		port = 8096
 		api_key = "%s"
+		update_library = true
+		map_from = "/tv"
+		map_to = "/media/tv"
 	}`, name, token)
 }

--- a/internal/provider/notification_plex_resource.go
+++ b/internal/provider/notification_plex_resource.go
@@ -44,6 +44,8 @@ type NotificationPlex struct {
 	Host                          types.String `tfsdk:"host"`
 	AuthToken                     types.String `tfsdk:"auth_token"`
 	Name                          types.String `tfsdk:"name"`
+	MapFrom                       types.String `tfsdk:"map_from"`
+	MapTo                         types.String `tfsdk:"map_to"`
 	ID                            types.Int64  `tfsdk:"id"`
 	Port                          types.Int64  `tfsdk:"port"`
 	UpdateLibrary                 types.Bool   `tfsdk:"update_library"`
@@ -65,6 +67,8 @@ func (n NotificationPlex) toNotification() *Notification {
 		Host:                          n.Host,
 		Name:                          n.Name,
 		AuthToken:                     n.AuthToken,
+		MapFrom:                       n.MapFrom,
+		MapTo:                         n.MapTo,
 		ID:                            n.ID,
 		Port:                          n.Port,
 		UpdateLibrary:                 n.UpdateLibrary,
@@ -88,6 +92,8 @@ func (n *NotificationPlex) fromNotification(notification *Notification) {
 	n.Host = notification.Host
 	n.Name = notification.Name
 	n.AuthToken = notification.AuthToken
+	n.MapFrom = notification.MapFrom
+	n.MapTo = notification.MapTo
 	n.ID = notification.ID
 	n.UpdateLibrary = notification.UpdateLibrary
 	n.Port = notification.Port
@@ -197,6 +203,16 @@ func (r *NotificationPlexResource) Schema(_ context.Context, _ resource.SchemaRe
 			"host": schema.StringAttribute{
 				MarkdownDescription: "Host.",
 				Required:            true,
+			},
+			"map_from": schema.StringAttribute{
+				MarkdownDescription: "Map from. Sonarr path, used to modify series paths when Plex sees library path location differently from Sonarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
+			},
+			"map_to": schema.StringAttribute{
+				MarkdownDescription: "Map to. Plex path, used to modify series paths when Plex sees library path location differently from Sonarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
 			},
 		},
 	}

--- a/internal/provider/notification_plex_resource_test.go
+++ b/internal/provider/notification_plex_resource_test.go
@@ -25,6 +25,8 @@ func TestAccNotificationPlexResource(t *testing.T) {
 				Config: testAccNotificationPlexResourceConfig("resourcePlexTest", "token123"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("sonarr_notification_plex.test", "auth_token", "token123"),
+					resource.TestCheckResourceAttr("sonarr_notification_plex.test", "map_from", "/tv"),
+					resource.TestCheckResourceAttr("sonarr_notification_plex.test", "map_to", "/media/tv"),
 					resource.TestCheckResourceAttrSet("sonarr_notification_plex.test", "id"),
 				),
 			},
@@ -68,5 +70,8 @@ func testAccNotificationPlexResourceConfig(name, token string) string {
 		host = "plex.lcl"
 		port = 32400
 		auth_token = "%s"
+		update_library = true
+		map_from = "/tv"
+		map_to = "/media/tv"
 	}`, name, token)
 }

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -29,7 +29,7 @@ var (
 
 var notificationFields = helpers.Fields{
 	Bools:                  []string{"alwaysUpdate", "cleanLibrary", "directMessage", "notify", "sendSilently", "updateLibrary", "useEuEndpoint", "useSsl"},
-	Strings:                []string{"accessToken", "accessTokenSecret", "apiKey", "appToken", "arguments", "author", "authToken", "authUser", "avatar", "botToken", "channel", "chatId", "consumerKey", "consumerSecret", "deviceNames", "expires", "from", "host", "icon", "mention", "password", "path", "refreshToken", "senderDomain", "senderId", "server", "signIn", "sound", "token", "url", "userKey", "username", "userName", "webHookUrl", "clickUrl", "serverUrl", "authUsername", "authPassword", "statelessUrls", "configurationKey", "senderNumber", "receiverId", "key", "event"},
+	Strings:                []string{"accessToken", "accessTokenSecret", "apiKey", "appToken", "arguments", "author", "authToken", "authUser", "avatar", "botToken", "channel", "chatId", "consumerKey", "consumerSecret", "deviceNames", "expires", "from", "host", "icon", "mention", "password", "path", "refreshToken", "senderDomain", "senderId", "server", "signIn", "sound", "token", "url", "userKey", "username", "userName", "webHookUrl", "clickUrl", "serverUrl", "authUsername", "authPassword", "statelessUrls", "configurationKey", "senderNumber", "receiverId", "key", "event", "mapFrom", "mapTo"},
 	Ints:                   []string{"method", "port", "priority", "retry", "expire", "displayTime", "notificationType", "useEncryption"},
 	StringSlices:           []string{"channelTags", "deviceIds", "devices", "recipients", "to", "cc", "bcc", "topics", "fieldTags"},
 	StringSlicesExceptions: []string{"tags"},
@@ -106,6 +106,8 @@ type Notification struct {
 	ConfigurationKey              types.String `tfsdk:"configuration_key"`
 	Key                           types.String `tfsdk:"key"`
 	Event                         types.String `tfsdk:"event"`
+	MapFrom                       types.String `tfsdk:"map_from"`
+	MapTo                         types.String `tfsdk:"map_to"`
 	NotificationType              types.Int64  `tfsdk:"notification_type"`
 	Expire                        types.Int64  `tfsdk:"expire"`
 	DisplayTime                   types.Int64  `tfsdk:"display_time"`
@@ -200,6 +202,8 @@ func (n Notification) getType() attr.Type {
 			"configuration_key":                  types.StringType,
 			"key":                                types.StringType,
 			"event":                              types.StringType,
+			"map_from":                           types.StringType,
+			"map_to":                             types.StringType,
 			"notification_type":                  types.Int64Type,
 			"expire":                             types.Int64Type,
 			"display_time":                       types.Int64Type,
@@ -427,6 +431,16 @@ func (r *NotificationResource) Schema(_ context.Context, _ resource.SchemaReques
 			},
 			"stateless_urls": schema.StringAttribute{
 				MarkdownDescription: "Stateless URLs.",
+				Optional:            true,
+				Computed:            true,
+			},
+			"map_from": schema.StringAttribute{
+				MarkdownDescription: "Map from. Sonarr path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')",
+				Optional:            true,
+				Computed:            true,
+			},
+			"map_to": schema.StringAttribute{
+				MarkdownDescription: "Map to. Media server path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')",
 				Optional:            true,
 				Computed:            true,
 			},

--- a/internal/provider/notifications_data_source.go
+++ b/internal/provider/notifications_data_source.go
@@ -193,6 +193,14 @@ func (d *NotificationsDataSource) Schema(_ context.Context, _ datasource.SchemaR
 							MarkdownDescription: "Stateless URLs.",
 							Computed:            true,
 						},
+						"map_from": schema.StringAttribute{
+							MarkdownDescription: "Map from. Sonarr path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')",
+							Computed:            true,
+						},
+						"map_to": schema.StringAttribute{
+							MarkdownDescription: "Map to. Media server path, used to modify series paths when the media server sees library path location differently from Sonarr (Requires 'Update Library')",
+							Computed:            true,
+						},
 						"configuration_key": schema.StringAttribute{
 							MarkdownDescription: "Configuration key.",
 							Computed:            true,


### PR DESCRIPTION
Exposes `map_from` / `map_to` on `sonarr_notification_emby` and `sonarr_notification_plex`. Both are optional.

Sonarr uses these to rewrite series paths when the media server sees the library at a different location than Sonarr does.
For example Sonarr has `/tv` and Jellyfin has `/media/tv`.